### PR TITLE
 Fix incorrect integer format specifiers

### DIFF
--- a/src/thd_cdev_rapl.cpp
+++ b/src/thd_cdev_rapl.cpp
@@ -495,12 +495,12 @@ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
 		}
 
 		if (pl0_max_pwr <= pl0_min_pwr) {
-			thd_log_info("Invalid limits: ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+			thd_log_info("Invalid limits: ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 					pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 			return false;
 		}
 
-		thd_log_info("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+		thd_log_info("ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 				pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 
 		int policy_matched;
@@ -570,12 +570,12 @@ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
 		int def_max_power;
 
 		if (pl0_max_pwr <= pl0_min_pwr) {
-			thd_log_info("Invalid limits: ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+			thd_log_info("Invalid limits: ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 					pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 			return false;
 		}
 
-		thd_log_info("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+		thd_log_info("ppcc limits max:%d min:%d  min_win:%d step:%d\n",
 				pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
 
 		def_max_power = rapl_read_pl1_max();

--- a/src/thd_engine_default.cpp
+++ b/src/thd_engine_default.cpp
@@ -310,7 +310,7 @@ bool cthd_engine_default::add_int340x_processor_dev(void)
 
 				thd_log_info("Processor thermal device is present \n");
 				thd_log_info("It will act as CPU thermal zone !! \n");
-				thd_log_info("Processor thermal device passive Trip is %d\n",
+				thd_log_info("Processor thermal device passive Trip is %u\n",
 						trip->get_trip_temp());
 
 				processor_thermal->set_zone_active();

--- a/src/thd_gddv.cpp
+++ b/src/thd_gddv.cpp
@@ -422,7 +422,7 @@ void cthd_gddv::dump_apct() {
 	for (unsigned int i = 0; i < conditions.size(); ++i) {
 		std::vector<struct condition> condition_set;
 
-		thd_log_info("condition_set %d\n", i);
+		thd_log_info("condition_set %u\n", i);
 		condition_set = conditions[i];
 		for (unsigned int j = 0; j < condition_set.size(); ++j) {
 			std::string cond_name, comp_str, op_str;

--- a/tools/thermal_monitor/ThermalMonitor.pro
+++ b/tools/thermal_monitor/ThermalMonitor.pro
@@ -14,7 +14,11 @@ CONFIG(release): DEFINES += QT_NO_DEBUG_OUTPUT
 TARGET = ThermalMonitor
 TEMPLATE = app
 
+# Depending on distro and QT version
+# name can be different, so choose correct one for your distro
 LIBS += -lQCustomPlot
+#LIBS += -lqcustomplot
+#LIBS += -lqcustomplot-qt6
 
 SOURCES += main.cpp\
         mainwindow.cpp \

--- a/tools/thermal_monitor/mainwindow.cpp
+++ b/tools/thermal_monitor/mainwindow.cpp
@@ -12,7 +12,7 @@
 */
 
 #include <QMessageBox>
-#include <QDesktopWidget>
+#include <QScreen>
 #include "mainwindow.h"
 #include "pollingdialog.h"
 #include "sensorsdialog.h"
@@ -79,7 +79,7 @@ void MainWindow::setupMenus()
     settingsMenu->addAction("Configure &polling interval", this, SLOT(configurePollingInterval()));
     settingsMenu->addAction("Configure &sensors", this, SLOT(configureSensors()));
     settingsMenu->addAction("&Clear settings and quit", this, SLOT(clearAndExit()));
-    settingsMenu->addAction("&Quit", this, SLOT(close()), QKeySequence::Quit);
+    settingsMenu->addAction("&Quit", this, SLOT(close()));
     QMenu *helpMenu = menuBar()->addMenu("&Help");
     helpMenu->addAction("&About", this, SLOT(showAboutDialog()));
 }
@@ -242,7 +242,7 @@ void MainWindow::updateTemperatureDataSlot()
         }
 
     if(logging_enabled) {
-        outStreamLogging << endl;
+            outStreamLogging << Qt::endl;
     }
 
     m_plotWidget->replot();
@@ -301,8 +301,8 @@ void MainWindow::loadSettings()
         move(settings.value("mainWindowGeometry/pos").toPoint());
     } else {
         // otherwise start with the default geometry calculated from the desktop size
-        QDesktopWidget desktop;
-        QRect screen = desktop.screenGeometry();
+	QScreen *qscreen = QGuiApplication::primaryScreen();
+        QRect screen = qscreen->availableGeometry();
         int width, height, x, y;
 
         width = screen.width() / DEFAULT_SCREEN_SIZE_DIVISOR;
@@ -403,7 +403,7 @@ void MainWindow::changeLogVariables(bool log_enabled, bool log_vis_only,
         QTextStream out(&logging_file);
         if (!logging_file.open(QIODevice::WriteOnly | QIODevice::Text)) {
             qCritical() << "Cannot open file for writing: "
-                        << qPrintable(logging_file.errorString()) << endl;
+                        << qPrintable(logging_file.errorString()) << Qt::endl;
             return;
         }
         outStreamLogging.setDevice(&logging_file);
@@ -414,7 +414,7 @@ void MainWindow::changeLogVariables(bool log_enabled, bool log_vis_only,
                 outStreamLogging << m_plotWidget->graph(i)->name() << ", ";
             }
         }
-        outStreamLogging << endl;
+        outStreamLogging << Qt::endl;
     }
 
     // logging has been turned off, so close the file

--- a/tools/thermal_monitor/tripsdialog.cpp
+++ b/tools/thermal_monitor/tripsdialog.cpp
@@ -124,9 +124,6 @@ void tripsDialog::on_treeWidget_clicked(const QModelIndex &index)
     // Alternate the background color, black to display on the graph, white to ignore
     if (trip != -1 && col == 1){ // if the user clicks on a temperature
         ui->label->setText("Zone: " + index.parent().data().toString());
-        ui->label_2->setText("Type: " +
-                             index.parent().child(trip, col + 1).data().toString()
-                             + " (°C)");
         ui->lineEdit->setText(index.data().toString());
 
         // ACTIVE_TRIP modification not supported at this time


### PR DESCRIPTION
There are a handful of incorrect %d or %u format specifiers being used
for integer values. Fix this.

Detected using cppcheck static code analysis.